### PR TITLE
A spelling correction in  autoindex_main.cpp

### DIFF
--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -275,7 +275,7 @@ int main_autoindex(int argc, char** argv) {
     }
     
     if (IndexingParameters::verbosity >= IndexingParameters::Basic) {
-        cerr << "[vg autoindex] Excecuting command:";
+        cerr << "[vg autoindex] Executing command:";
         for (int i = 0; i < argc; ++i) {
             cerr << " " << argv[i];
         }


### PR DESCRIPTION
Spelling

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Spelling corrected!

## Description
I'll be famous now. :-)
